### PR TITLE
Hostname blacklisting added

### DIFF
--- a/ddserver/resources/doc/ddserver.conf.example
+++ b/ddserver/resources/doc/ddserver.conf.example
@@ -15,6 +15,7 @@ password = YourDatabasePassword
 [dns]
 ;max_hosts = 5
 ;ttl = 60
+;blacklist = www, mail, ftp, test
 
 [signup]
 ;enabled = True


### PR DESCRIPTION
Allow the user to specify blacklisted host names in the config file. These hosts will not be valid during adding a host in the UI.
